### PR TITLE
CI: make npm audit blocking on high/critical

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-      - name: npm audit (informational)
-        run: npm audit --omit=dev || true
+      - name: npm audit (blocking on high/critical)
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
## What

Makes the `npm audit` step in `.github/workflows/security.yml` **blocking on high/critical** vulnerabilities instead of being swallowed by `|| true`.

- Before: `npm audit --omit=dev || true` (informational — never fails CI)
- After: `npm audit --omit=dev --audit-level=high` (fails CI on high/critical)

`--omit=dev` is preserved, so only production dependencies are audited.

## Why

App-repo hardening from the fleet security audit — e-xode/scripts#3, finding #18.

Co-authored-by: AI Assistant <ai-assistant@users.noreply.github.com>